### PR TITLE
Added ability to retrieve list of all user's decks and all of the cards belonging to each deck

### DIFF
--- a/spaced-repetition-back-end/routes/decks/decksModel.js
+++ b/spaced-repetition-back-end/routes/decks/decksModel.js
@@ -6,6 +6,7 @@ module.exports = {
   findById,
   findByAuthor,
   findByJct,
+  cardsArrTest,
   add,
   update,
   remove
@@ -30,6 +31,13 @@ function findByJct(id) {
   return db(table)
     .innerJoin('userDeck', 'decks.id', 'userDeck.deck_id')
     .where('userDeck.user_id', id)
+}
+
+function cardsArrTest(id) {
+  return db(table)
+  .innerJoin('userDeck', 'decks.id', 'userDeck.deck_id')
+  .innerJoin('cards', 'decks.id', 'cards.deck_id')
+  .where('userDeck.user_id', id)
 }
 
 function add(entry) {

--- a/spaced-repetition-back-end/routes/decks/decksRoutes.js
+++ b/spaced-repetition-back-end/routes/decks/decksRoutes.js
@@ -44,6 +44,59 @@ router.get('/jct/:id', (req, res) => {
     .catch(err => res.status(500).json(err));
 });
 
+router.get('/test/:id', (req, res) => {
+  // do the findByJct to get all user's decks
+  // then, get the deck_id from each
+  function format(arr) {
+    let deckNames = {};
+    let formattedData = [];
+    let count = 0;
+    for (let i = 0; i < arr.length; i++) {
+      // if deck exists, push just the card to the object's card array
+      if (deckNames[arr[i].name]) {
+        formattedData[deckNames[arr[i].name]].cards.push({
+            "id": arr[i].id,
+            "title": arr[i].title,
+            "question": arr[i].question,
+            "answer": arr[i].answer,
+            "language": arr[i].language
+          })
+      } else {
+        // if deck does not exist, push the deck to formattedData array
+        // add property to deckname objects and assign value of count (for referencing in the array)
+        deckNames[arr[i].name] = count++;
+        formattedData.push({
+          "id": arr[i].deck_id,
+          "name": arr[i].name,
+          "public": arr[i].public,
+          "author": arr[i].author,
+          "user_id": arr[i].user_id,
+          "cards": [{
+            "id": arr[i].id,
+            "title": arr[i].title,
+            "question": arr[i].question,
+            "answer": arr[i].answer,
+            "language": arr[i].language
+          }] 
+        })
+      }
+    }
+    return formattedData;
+  }
+  decks
+    .cardsArrTest(req.params.id)
+    .then(decks => {
+      // let decksArr = [];
+      // decks.forEach((x, i) => {
+      //   x.cards = ['test', 'yeah'];
+      // })
+      // // decks['cards'] = decksArr;
+      // console.log(decks)
+      res.status(200).json(format(decks));
+    })
+    .catch(err => res.status(500).json(err));
+});
+
 router.post('/', (req, res) => {
   const user = req.body;
 

--- a/spaced-repetition-back-end/routes/decks/decksRoutes.js
+++ b/spaced-repetition-back-end/routes/decks/decksRoutes.js
@@ -45,8 +45,6 @@ router.get('/jct/:id', (req, res) => {
 });
 
 router.get('/test/:id', (req, res) => {
-  // do the findByJct to get all user's decks
-  // then, get the deck_id from each
   function format(arr) {
     let deckNames = {};
     let formattedData = [];

--- a/spaced-repetition-back-end/routes/decks/decksRoutes.js
+++ b/spaced-repetition-back-end/routes/decks/decksRoutes.js
@@ -86,12 +86,6 @@ router.get('/test/:id', (req, res) => {
   decks
     .cardsArrTest(req.params.id)
     .then(decks => {
-      // let decksArr = [];
-      // decks.forEach((x, i) => {
-      //   x.cards = ['test', 'yeah'];
-      // })
-      // // decks['cards'] = decksArr;
-      // console.log(decks)
       res.status(200).json(format(decks));
     })
     .catch(err => res.status(500).json(err));


### PR DESCRIPTION
DO NOT MERGE (yet).

I've added the capability to retrieve a list of all the user's decks (including shared/imported decks) and all of the cards belonging to each deck.The functionality is complete and quite efficient -- only one call is made to the db, and all of the formatting of the data is done in a single loop.

However, I would like to revise the endpoints where this functionality is taking place before merging. Currently it's taking place at endpoint called `/api/decks/test/:id`. Ideally this should be moved to `/api/users/:id/decks`. It won't be hard to do this, I just haven't gotten to it yet. I would also like to go through and clean up some of the additional endpoints before merging.