### PR TITLE
Add deck sidebar

### DIFF
--- a/spaced-repetition-front-end/src/components/Sidebar.js
+++ b/spaced-repetition-front-end/src/components/Sidebar.js
@@ -12,6 +12,16 @@ const Sidebar = () => (
       <ItemName>Decks</ItemName>
     </SidebarItem>
     <Divider />
+    <SidebarItem to="/dashboard/add-deck">
+      <Logo src={decksIcon} />
+      <ItemName>Add Deck</ItemName>
+    </SidebarItem>
+    <Divider />
+    <SidebarItem to="/dashboard/add-card">
+      <Logo src={decksIcon} />
+      <ItemName>Add Card</ItemName>
+    </SidebarItem>
+    <Divider />
   </Container>
 );
 
@@ -25,13 +35,13 @@ const Container = styled.div`
   align-items: center;
   width: 200px;
   height: 100%;
-  padding: 20px;
+  padding: 5px 20px 0;
   background: ${props => props.theme.dark.sidebar};
 `;
 
 const SidebarItem = styled(Link)`
   display: flex;
-  justify-content: center;
+  justify-content: end;
   align-items: center;
   padding: 5px;
   width: 100%;

--- a/spaced-repetition-front-end/src/components/Sidebar.js
+++ b/spaced-repetition-front-end/src/components/Sidebar.js
@@ -28,6 +28,8 @@ const Sidebar = () => (
 export default Sidebar;
 
 // styles
+// No idea what is causing it, but without min-width, container shrinks to
+// 192px when decks is selected, but stays at 200px when on add decks or add cards
 const Container = styled.div`
   display: flex;
   flex-direction: column;
@@ -37,6 +39,7 @@ const Container = styled.div`
   height: 100%;
   padding: 5px 20px 0;
   background: ${props => props.theme.dark.sidebar};
+  min-width: 200px;
 `;
 
 const SidebarItem = styled(Link)`


### PR DESCRIPTION
Made links to both add-deck and add-card on the sidebar. Note: currently we have not yet implemented logos, so I just used the same logo used for decks just to keep things looking clean without investing time in adding logos atm. Group decided adding logos was low priority at this time. Will revisit later and likely implement font awesome.