### PR TITLE
Deletes cards in training mode

### DIFF
--- a/spaced-repetition-front-end/src/App.js
+++ b/spaced-repetition-front-end/src/App.js
@@ -195,6 +195,32 @@ class App extends Component {
     this.setState({ profile });
   }
 
+  handleCardDeletion = (cardId, deckId) => {
+    const token = localStorage.getItem('id_token');
+    const headers = { Authorization: `Bearer ${token}` };
+
+    axios.delete(`${process.env.REACT_APP_URL}/api/cards/${cardId}`, { headers })
+      .then(() => {
+        const { decks } = this.state;
+        // The db response is 1 for success, it does not return an updated array of decks.
+        // updatedDecks returns a new array of decks with the recently deleted deck removed.
+        const updatedDecks = decks.map((deck) => {
+          if (Number(deck.id) === Number(deckId)) {
+            deck.cards.map((card, i) => {
+              if (Number(card.id) === Number(cardId)) {
+                deck.cards.splice(i, 1);
+              }
+            });
+          }
+          return deck;
+        });
+        this.setState({
+          decks: updatedDecks,
+        });
+      })
+      .catch(err => console.log(new Error(err)));
+  }
+
   render() {
     const { decks, profile } = this.state;
     return (
@@ -224,7 +250,7 @@ class App extends Component {
               path="/dashboard/decks/:deckId/train"
               render={(props) => {
                 const deckToTrain = this.handleTrainDeck(props);
-                return <TrainDeck deck={deckToTrain[0]} updateProgress={this.addCardToUpdate} {...props} />;
+                return <TrainDeck deck={deckToTrain[0]} deleteCard={this.handleCardDeletion} updateProgress={this.addCardToUpdate} {...props} />;
               }}
             />
           </Wrapper>

--- a/spaced-repetition-front-end/src/App.js
+++ b/spaced-repetition-front-end/src/App.js
@@ -12,8 +12,8 @@ import Profile from './components/Profile';
 import Billing from './components/Billing';
 import AddDeck from './components/AddDeck';
 import AddCard from './components/AddCard';
-import CardInputs from './components/CardInputs';
 import TrainDeck from './components/TrainDeck';
+import DeleteCardModal from './components/DeleteCardModal';
 import './App.css';
 
 
@@ -250,8 +250,13 @@ class App extends Component {
               path="/dashboard/decks/:deckId/train"
               render={(props) => {
                 const deckToTrain = this.handleTrainDeck(props);
-                return <TrainDeck deck={deckToTrain[0]} deleteCard={this.handleCardDeletion} updateProgress={this.addCardToUpdate} {...props} />;
+                return <TrainDeck deck={deckToTrain[0]} updateProgress={this.addCardToUpdate} {...props} />;
               }}
+            />
+            <Route
+              exact
+              path="/dashboard/decks/:deckId/train/:id/delete"
+              render={props => <DeleteCardModal deleteCard={this.handleCardDeletion} {...props} />}
             />
           </Wrapper>
         </Switch>

--- a/spaced-repetition-front-end/src/components/Card.js
+++ b/spaced-repetition-front-end/src/components/Card.js
@@ -114,6 +114,13 @@ class Card extends React.Component {
     this.setState({ redirect: true });
   }
 
+  handleDeleteCard = () => {
+    const { data, deleteCard } = this.props;
+    const { currentCard } = this.state;
+    const { id } = data.cards[currentCard];
+    deleteCard(id, data.id);
+  }
+
   handleAnswer(difficulty) {
     // object to send to server: {difficulty: '', cardID: ''};
     const { data, updateProgress } = this.props;
@@ -131,7 +138,6 @@ class Card extends React.Component {
       trained, currentCard, showOptions, showNext, redirect, qContentType, aContentType,
       qFilteredContent, aFilteredContent,
     } = this.state;
-
     if (redirect) return <Redirect to="/dashboard/decks" />;
     return (
       data ? (
@@ -205,6 +211,11 @@ class Card extends React.Component {
                 onClick={this.quitTrainingSession}
               >
                 Quit current training session.
+              </OptionItem>
+              <OptionItem
+                onClick={this.handleDeleteCard}
+              >
+                Delete card.
               </OptionItem>
             </OptionsMenu>
           </CardModal>
@@ -359,4 +370,5 @@ Card.defaultProps = {
 Card.propTypes = {
   data: PropTypes.shape(),
   updateProgress: PropTypes.func.isRequired,
+  deleteCard: PropTypes.func.isRequired,
 };

--- a/spaced-repetition-front-end/src/components/Card.js
+++ b/spaced-repetition-front-end/src/components/Card.js
@@ -114,13 +114,6 @@ class Card extends React.Component {
     this.setState({ redirect: true });
   }
 
-  handleDeleteCard = () => {
-    const { data, deleteCard } = this.props;
-    const { currentCard } = this.state;
-    const { id } = data.cards[currentCard];
-    deleteCard(id, data.id);
-  }
-
   handleAnswer(difficulty) {
     // object to send to server: {difficulty: '', cardID: ''};
     const { data, updateProgress } = this.props;
@@ -136,7 +129,7 @@ class Card extends React.Component {
     const { data, updateProgress } = this.props;
     const {
       trained, currentCard, showOptions, showNext, redirect, qContentType, aContentType,
-      qFilteredContent, aFilteredContent,
+      qFilteredContent, aFilteredContent, showModal,
     } = this.state;
     if (redirect) return <Redirect to="/dashboard/decks" />;
     return (
@@ -212,11 +205,9 @@ class Card extends React.Component {
               >
                 Quit current training session.
               </OptionItem>
-              <OptionItem
-                onClick={this.handleDeleteCard}
-              >
-                Delete card.
-              </OptionItem>
+              <OptionItemLink to={`/dashboard/decks/${data.id}/train/${data.cards[currentCard].id}/delete`}>
+                Delete thid card.
+              </OptionItemLink>
             </OptionsMenu>
           </CardModal>
         </MainCardContainer>
@@ -345,6 +336,15 @@ const OptionItem = styled(CardText)`
   }
 `;
 
+const OptionItemLink = styled(Link)`
+  text-align: end;
+  cursor: pointer;
+        
+  &:hover {
+    color: turquoise;
+  }
+`;
+
 // animation styling
 const FadeIn = keyframes`
   0% {
@@ -370,5 +370,4 @@ Card.defaultProps = {
 Card.propTypes = {
   data: PropTypes.shape(),
   updateProgress: PropTypes.func.isRequired,
-  deleteCard: PropTypes.func.isRequired,
 };

--- a/spaced-repetition-front-end/src/components/Card.js
+++ b/spaced-repetition-front-end/src/components/Card.js
@@ -206,7 +206,7 @@ class Card extends React.Component {
                 Quit current training session.
               </OptionItem>
               <OptionItemLink to={`/dashboard/decks/${data.id}/train/${data.cards[currentCard].id}/delete`}>
-                Delete thid card.
+                Delete this card.
               </OptionItemLink>
             </OptionsMenu>
           </CardModal>

--- a/spaced-repetition-front-end/src/components/DeleteCardModal.js
+++ b/spaced-repetition-front-end/src/components/DeleteCardModal.js
@@ -1,0 +1,22 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const DeleteCardModal = ({ match, deleteCard }) => {
+  const handleDelete = () => {
+    deleteCard(match.params.id, match.params.deckId);
+  }
+  return (
+    <div>
+      <p>Are you sure you want to delete this card?</p>
+      <button type="button" onClick={handleDelete}>Delete</button>
+      <button type="button">Cancel</button>
+    </div>
+  );
+};
+
+export default DeleteCardModal;
+
+DeleteCardModal.propTypes = {
+  deleteCard: PropTypes.func.isRequired,
+  match: PropTypes.instanceOf(Object).isRequired,
+};

--- a/spaced-repetition-front-end/src/components/DeleteCardModal.js
+++ b/spaced-repetition-front-end/src/components/DeleteCardModal.js
@@ -1,18 +1,32 @@
-import React from 'react';
+import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 
-const DeleteCardModal = ({ match, deleteCard }) => {
-  const handleDelete = () => {
-    deleteCard(match.params.id, match.params.deckId);
+class DeleteCardModal extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      wasDeleted: false,
+    };
   }
-  return (
-    <div>
-      <p>Are you sure you want to delete this card?</p>
-      <button type="button" onClick={handleDelete}>Delete</button>
-      <button type="button">Cancel</button>
-    </div>
-  );
-};
+
+  handleDelete = () => {
+    const { match, deleteCard } = this.props;
+    deleteCard(match.params.id, match.params.deckId);
+    this.setState({ wasDeleted: true });
+  }
+
+  render() {
+    const { wasDeleted } = this.state;
+    return (
+      <div>
+        {!wasDeleted && <p>Are you sure you want to delete this card?</p>}
+        {wasDeleted && <p>Your card was successfully deleted.</p>}
+        <button type="button" onClick={this.handleDelete}>Delete</button>
+        <button type="button">Cancel</button>
+      </div>
+    );
+  }
+}
 
 export default DeleteCardModal;
 

--- a/spaced-repetition-front-end/src/components/TrainDeck.js
+++ b/spaced-repetition-front-end/src/components/TrainDeck.js
@@ -3,14 +3,14 @@ import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import Card from './Card';
 
-const TrainDeck = ({ deck, updateProgress, deleteCard }) => (
+const TrainDeck = ({ deck, updateProgress }) => (
   <TrainingContainer>
     <TrainingHeader>
       Currently training:
       {' '}
       {deck ? deck.name : 'Loading...'}
     </TrainingHeader>
-    <Card data={deck} updateProgress={updateProgress} deleteCard={deleteCard} />
+    <Card data={deck} updateProgress={updateProgress} />
   </TrainingContainer>
 );
 
@@ -29,5 +29,4 @@ TrainDeck.defaultProps = {
 TrainDeck.propTypes = {
   deck: PropTypes.shape(),
   updateProgress: PropTypes.func.isRequired,
-  deleteCard: PropTypes.func.isRequired,
 };

--- a/spaced-repetition-front-end/src/components/TrainDeck.js
+++ b/spaced-repetition-front-end/src/components/TrainDeck.js
@@ -3,14 +3,14 @@ import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import Card from './Card';
 
-const TrainDeck = ({ deck, updateProgress }) => (
+const TrainDeck = ({ deck, updateProgress, deleteCard }) => (
   <TrainingContainer>
     <TrainingHeader>
       Currently training:
       {' '}
       {deck ? deck.name : 'Loading...'}
     </TrainingHeader>
-    <Card data={deck} updateProgress={updateProgress} />
+    <Card data={deck} updateProgress={updateProgress} deleteCard={deleteCard} />
   </TrainingContainer>
 );
 
@@ -29,4 +29,5 @@ TrainDeck.defaultProps = {
 TrainDeck.propTypes = {
   deck: PropTypes.shape(),
   updateProgress: PropTypes.func.isRequired,
+  deleteCard: PropTypes.func.isRequired,
 };


### PR DESCRIPTION
# Description
In training mode, a user may delete the card there instead of navigating to another part of the site. The delete call to the db does not return a new decks array, and instead of making another call to the db, upon success the decks array in App state is filtered to remove that card.

- [x] New feature (non-breaking change which adds functionality)

## Change status
- [ ] Complete, tested, ready to review and merge
- [ ] Complete, but not tested (may need new tests)
- [x] Incomplete/work-in-progress, PR is for discussion/feedback

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] There are no merge conflicts

# Bugs to fix in future
- If a user deletes all their cards from a deck and tries to access that deck afterwards, it will break the app.
- Users are not automagically redirected back to the training session after deletion.
- Cancel does not redirect users back to their current place in the session.